### PR TITLE
Fix update-pot target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ add_custom_target(update-pot
 			--no-location
 			--keyword=_ --keyword=N_
 			--files-from=${CMAKE_CURRENT_SOURCE_DIR}/POTFILES.in
+			--directory=tools
+			--directory=build
+			--directory=.
 	  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	  SOURCES ${POT_SOURCES}
 )

--- a/POTFILES.in
+++ b/POTFILES.in
@@ -1,7 +1,6 @@
 # List of files which contain translatable strings.
 cliutils.c
 rpm2archive.c
-rpm2cpio.c
 rpmbuild.c
 rpmdb.c
 rpmkeys.c


### PR DESCRIPTION
Target `update-pot` complained about not finding sources in the `tools` directory. Additionally, `POTFILES.in` was not updated when `rpm2cpio` was retired and `rpm2cpio.c` removed from the repository.
See [rpm issue #2817](https://github.com/rpm-software-management/rpm/issues/2817).